### PR TITLE
Support connection charset setting

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -134,7 +134,12 @@ Client.prototype.disconnect = function() {
 
 Client.prototype.doConnect = function() {
   var config = this.config;
-  this.client = mysql.createConnectionSync(config.host, config.user, config.password, config.database, config.port);
+  this.client = mysql.createConnectionSync();
+  this.client.initSync();
+  if (config.charset) {
+    this.client.setOptionSync(mysql.MYSQL_SET_CHARSET_NAME, config.charset);
+  }
+  this.client.realConnectSync(config.host, config.user, config.password, config.database, config.port);
   if (config.database) {
     this.client.query('USE '+config.database);
   }


### PR DESCRIPTION
I had issue like https://github.com/Sannis/node-mysql-libmysqlclient/issues/131 and think it's good little feature - setting of charset for connection in Client. (or I see lots of "?" instead of localized symbols :)) 
